### PR TITLE
optgroup invasions

### DIFF
--- a/ImageSelect.jquery.js
+++ b/ImageSelect.jquery.js
@@ -149,8 +149,14 @@
                     //      The event object
                     // _chosen: Object {chosen:Chosen}
                     //      Contains the current instance of Chosen class
-                    var lis = $(chosen.container).find('.chosen-drop ul li:not(:has(img))')
-                    var options = $(chosen.form_field).find('optgroup, option');
+                    /****************************************************/
+                    /**///The reason I found this change necessary  was because my optgroups kept getting images from
+                    /**///surrounding options prepended inside of them after line 172 executed resulting in broken ugly drop downs
+                    /**///I don't thin optgroups should have images so they can stand out from options that do have images
+                    /**///find chosen-drop ul li.group-option fits this case better than find chosen-drop ul li not image
+                    var lis = $(chosen.container).find('.chosen-drop ul li.group-option'); //find('.chosen-drop ul li:not(:has(img)))
+                    /**///removed optgroup from this in order to match the arrays correctly works much better now
+                    var options = $(chosen.form_field).find('option'); //('optgroup, option');
                     
                     for(var i = 0; i < lis.length; i++){
                         var li = lis[i];


### PR DESCRIPTION
The reason I found this change necessary was because my optgroups kept getting images from surrounding options prepended inside of them after line 172 executed resulting in broken ugly drop downs

My case.

```
<select class="fabrics-chosen-dropdown" id="unique" data-placeholder="Type the name of your fabric here..." multiple="multiple">
    <?php
    foreach ($fabrics as $key => $val){ ?>
        <optgroup label="<?php echo ucwords($key); ?>">
            <?php for ($i = 0; $i < count($val); $i++) { ?>
                <option data-img-src="/media/fabrics/<?php echo $key . '/' . $val[$i]->fabric_image_small; ?>"><?php echo $val[$i]->fabric_title; ?></option>
            <?php } ?>
        </optgroup>
    <?php } ?>
</select>
```

Would wind up with a terrorized optgroup.

```
<li class="group-result"><img class="clr chosenfabopt chose-image-list" src="/media/fabrics/basic/Fabric_435_sm.jpg">Premier</li>
```

![635676651309362466](https://cloud.githubusercontent.com/assets/1281104/7717508/5b085cb6-fe68-11e4-81f2-d4de1fc9577e.png)
